### PR TITLE
Using the actual supported country codes from the translator

### DIFF
--- a/faster_auto_subtitle/cli.py
+++ b/faster_auto_subtitle/cli.py
@@ -1,5 +1,4 @@
 import argparse
-from .utils.constants import LANGUAGE_CODES
 from .utils.convert import str2bool, str2timeinterval
 import json
 
@@ -56,12 +55,10 @@ def main():
                               or X->Language translation ('translate')")
 
     parser.add_argument("--language", type=str, default="auto",
-                        choices=LANGUAGE_CODES,
                         help="What is the origin language of the video? \
                               If unset, it is detected automatically.")
 
     parser.add_argument("--target_language", type=str, default="en",
-                        choices=LANGUAGE_CODES,
                         help="Desired language to translate subtitles to. \
                               If language is not en, Opus-MT will be used. \
                               See https://github.com/Helsinki-NLP/Opus-MT.")


### PR DESCRIPTION
Instead of using a static list of languages we'll verify against the actual list that the provider supports 